### PR TITLE
Adds more CleverTap profile property related methods with Android support

### DIFF
--- a/Plugins/CleverTap/Source/CleverTap/Private/Android/AndroidCleverTapJNI.cpp
+++ b/Plugins/CleverTap/Source/CleverTap/Private/Android/AndroidCleverTapJNI.cpp
@@ -501,6 +501,27 @@ void PushChargedEvent(JNIEnv* Env, jobject CleverTapInstance, jobject ChargeDeta
 	}
 }
 
+jobject GetProperty(JNIEnv* Env, jobject CleverTapInstance, const FString& Key)
+{
+	static jclass CleverTapAPIClass = GetCleverTapAPIClass(Env);
+	static jmethodID GetPropertyMethod =
+		GetMethodID(Env, CleverTapAPIClass, "getProperty", "(Ljava/lang/String;)Ljava/lang/Object;");
+	if (!GetPropertyMethod)
+	{
+		return nullptr;
+	}
+
+	jstring JavaKey = Env->NewStringUTF(TCHAR_TO_UTF8(*Key));
+	jobject JavaValue = Env->CallObjectMethod(CleverTapInstance, GetPropertyMethod, JavaKey);
+	if (HandleException(Env, "getProperty()"))
+	{
+		// already logged; fall through
+	}
+	Env->DeleteLocalRef(JavaKey);
+
+	return JavaValue;
+}
+
 static void DecrementValue(JNIEnv* Env, jobject CleverTapInstance, const FString& Key, jobject Amount)
 {
 	static jclass CleverTapAPIClass = GetCleverTapAPIClass(Env);
@@ -610,6 +631,112 @@ void IncrementValue(JNIEnv* Env, jobject CleverTapInstance, const FString& Key, 
 	}
 	IncrementValue(Env, CleverTapInstance, Key, NumberObj);
 	Env->DeleteLocalRef(NumberObj);
+}
+
+void AddMultiValueForKey(JNIEnv* Env, jobject CleverTapInstance, const FString& Key, const FString& Value)
+{
+	static jclass CleverTapAPIClass = GetCleverTapAPIClass(Env);
+	static jmethodID AddMultiValueMethod =
+		GetMethodID(Env, CleverTapAPIClass, "addMultiValueForKey", "(Ljava/lang/String;Ljava/lang/String;)V");
+	if (!AddMultiValueMethod)
+	{
+		return;
+	}
+
+	jstring JavaKey = Env->NewStringUTF(TCHAR_TO_UTF8(*Key));
+	jstring JavaValue = Env->NewStringUTF(TCHAR_TO_UTF8(*Value));
+	Env->CallVoidMethod(CleverTapInstance, AddMultiValueMethod, JavaKey, JavaValue);
+	HandleException(Env, "addMultiValueForKey()");
+	Env->DeleteLocalRef(JavaKey);
+	Env->DeleteLocalRef(JavaValue);
+}
+
+void AddMultiValuesForKey(JNIEnv* Env, jobject CleverTapInstance, const FString& Key, const TArray<FString> Values)
+{
+	static jclass CleverTapAPIClass = GetCleverTapAPIClass(Env);
+	static jmethodID AddMultiValuesMethod =
+		GetMethodID(Env, CleverTapAPIClass, "addMultiValuesForKey", "(Ljava/lang/String;Ljava/util/ArrayList;)V");
+	if (!AddMultiValuesMethod)
+	{
+		return;
+	}
+
+	jstring JavaKey = Env->NewStringUTF(TCHAR_TO_UTF8(*Key));
+	jobject JavaValues = StringArrayToJavaArrayList(Env, Values);
+	Env->CallVoidMethod(CleverTapInstance, AddMultiValuesMethod, JavaKey, JavaValues);
+	HandleException(Env, "addMultiValuesForKey()");
+	Env->DeleteLocalRef(JavaKey);
+	Env->DeleteLocalRef(JavaValues);
+}
+
+void RemoveMultiValueForKey(JNIEnv* Env, jobject CleverTapInstance, const FString& Key, const FString& Value)
+{
+	static jclass CleverTapAPIClass = GetCleverTapAPIClass(Env);
+	static jmethodID RemoveMultiValueMethod =
+		GetMethodID(Env, CleverTapAPIClass, "removeMultiValueForKey", "(Ljava/lang/String;Ljava/lang/String;)V");
+	if (!RemoveMultiValueMethod)
+	{
+		return;
+	}
+
+	jstring JavaKey = Env->NewStringUTF(TCHAR_TO_UTF8(*Key));
+	jstring JavaValue = Env->NewStringUTF(TCHAR_TO_UTF8(*Value));
+	Env->CallVoidMethod(CleverTapInstance, RemoveMultiValueMethod, JavaKey, JavaValue);
+	HandleException(Env, "removeMultiValueForKey()");
+	Env->DeleteLocalRef(JavaKey);
+	Env->DeleteLocalRef(JavaValue);
+}
+
+void RemoveMultiValuesForKey(JNIEnv* Env, jobject CleverTapInstance, const FString& Key, const TArray<FString>& Values)
+{
+	static jclass CleverTapAPIClass = GetCleverTapAPIClass(Env);
+	static jmethodID RemoveMultiValuesMethod =
+		GetMethodID(Env, CleverTapAPIClass, "removeMultiValuesForKey", "(Ljava/lang/String;Ljava/util/ArrayList;)V");
+	if (!RemoveMultiValuesMethod)
+	{
+		return;
+	}
+
+	jstring JavaKey = Env->NewStringUTF(TCHAR_TO_UTF8(*Key));
+	jobject JavaValues = StringArrayToJavaArrayList(Env, Values);
+	Env->CallVoidMethod(CleverTapInstance, RemoveMultiValuesMethod, JavaKey, JavaValues);
+	HandleException(Env, "removeMultiValuesForKey()");
+	Env->DeleteLocalRef(JavaKey);
+	Env->DeleteLocalRef(JavaValues);
+}
+
+void RemoveValueForKey(JNIEnv* Env, jobject CleverTapInstance, const FString& Key)
+{
+	static jclass CleverTapAPIClass = GetCleverTapAPIClass(Env);
+	static jmethodID RemoveValueMethod =
+		GetMethodID(Env, CleverTapAPIClass, "removeValueForKey", "(Ljava/lang/String;)V");
+	if (!RemoveValueMethod)
+	{
+		return;
+	}
+
+	jstring JavaKey = Env->NewStringUTF(TCHAR_TO_UTF8(*Key));
+	Env->CallVoidMethod(CleverTapInstance, RemoveValueMethod, JavaKey);
+	HandleException(Env, "removeMultiValueForKey()");
+	Env->DeleteLocalRef(JavaKey);
+}
+
+void SetMultiValuesForKey(JNIEnv* Env, jobject CleverTapInstance, const FString& Key, const TArray<FString> Values)
+{
+	static jclass CleverTapAPIClass = GetCleverTapAPIClass(Env);
+	static jmethodID SetMultiValuesMethod =
+		GetMethodID(Env, CleverTapAPIClass, "setMultiValuesForKey", "(Ljava/lang/String;Ljava/util/ArrayList;)V");
+	if (!SetMultiValuesMethod)
+	{
+		return;
+	}
+
+	jstring JavaKey = Env->NewStringUTF(TCHAR_TO_UTF8(*Key));
+	jobject JavaValues = StringArrayToJavaArrayList(Env, Values);
+	Env->CallVoidMethod(CleverTapInstance, SetMultiValuesMethod, JavaKey, JavaValues);
+	HandleException(Env, "setMultiValuesForKey()");
+	Env->DeleteLocalRef(JavaKey);
+	Env->DeleteLocalRef(JavaValues);
 }
 
 bool IsPushPermissionGranted(JNIEnv* Env, jobject CleverTapInstance)

--- a/Plugins/CleverTap/Source/CleverTap/Private/Android/AndroidCleverTapJNI.h
+++ b/Plugins/CleverTap/Source/CleverTap/Private/Android/AndroidCleverTapJNI.h
@@ -37,11 +37,20 @@ void PushEvent(JNIEnv* Env, jobject CleverTapInstance, const FString& EventName)
 void PushEvent(JNIEnv* Env, jobject CleverTapInstance, const FString& EventName, jobject Actions);
 void PushChargedEvent(JNIEnv* Env, jobject CleverTapInstance, jobject Actions, jobject Items);
 
+jobject GetProperty(JNIEnv* Env, jobject CleverTapInstance, const FString& Key);
+
 void DecrementValue(JNIEnv* Env, jobject CleverTapInstance, const FString& Key, int Amount);
 void DecrementValue(JNIEnv* Env, jobject CleverTapInstance, const FString& Key, double Amount);
 
 void IncrementValue(JNIEnv* Env, jobject CleverTapInstance, const FString& Key, int Amount);
 void IncrementValue(JNIEnv* Env, jobject CleverTapInstance, const FString& Key, double Amount);
+
+void AddMultiValueForKey(JNIEnv* Env, jobject CleverTapInstance, const FString& Key, const FString& Value);
+void AddMultiValuesForKey(JNIEnv* Env, jobject CleverTapInstance, const FString& Key, const TArray<FString> Values);
+void RemoveMultiValueForKey(JNIEnv* Env, jobject CleverTapInstance, const FString& Key, const FString& Value);
+void RemoveMultiValuesForKey(JNIEnv* Env, jobject CleverTapInstance, const FString& Key, const TArray<FString>& Values);
+void RemoveValueForKey(JNIEnv* Env, jobject CleverTapInstance, const FString& Key);
+void SetMultiValuesForKey(JNIEnv* Env, jobject CleverTapInstance, const FString& Key, const TArray<FString> Values);
 
 bool IsPushPermissionGranted(JNIEnv* Env, jobject CleverTapInstance);
 void PromptForPushPermission(JNIEnv* Env, jobject CleverTapInstance, bool bFallbackToSettings);

--- a/Plugins/CleverTap/Source/CleverTap/Private/Android/AndroidCleverTapPropertiesJNI.cpp
+++ b/Plugins/CleverTap/Source/CleverTap/Private/Android/AndroidCleverTapPropertiesJNI.cpp
@@ -632,9 +632,14 @@ FCleverTapPropertyValue ConvertJavaObjectToCleverTapPropertyValue(JNIEnv* Env, j
 	static jmethodID HasNextMethod = GetMethodID(Env, IteratorClass, "hasNext", "()Z");
 	static jmethodID NextMethod = GetMethodID(Env, IteratorClass, "next", "()Ljava/lang/Object;");
 
+	// JSONArray support
+	static jclass JSONArrayClass = CacheClass(Env, "org/json/JSONArray");
+	static jmethodID JSONArrayLengthMethod = GetMethodID(Env, JSONArrayClass, "length", "()I");
+	static jmethodID JSONArrayGetMethod = GetMethodID(Env, JSONArrayClass, "getString", "(I)Ljava/lang/String;");
+
 	// Make sure we got everything
 	if (!GetIntValue || !GetLongValue || !GetDoubleValue || !GetFloatValue || !GetBooleanValue || !StringClass
-		|| !CollectionIteratorMethod || !HasNextMethod || !NextMethod)
+		|| !CollectionIteratorMethod || !HasNextMethod || !NextMethod || !JSONArrayLengthMethod || !JSONArrayGetMethod)
 	{
 		UE_LOG(LogCleverTap, Error, TEXT("Missing Vital Methods!"));
 		return FCleverTapPropertyValue();
@@ -714,6 +719,31 @@ FCleverTapPropertyValue ConvertJavaObjectToCleverTapPropertyValue(JNIEnv* Env, j
 			Env->DeleteLocalRef(Element);
 		}
 		Env->DeleteLocalRef(Iterator);
+		return FCleverTapPropertyValue(StringArray);
+	}
+
+	if (Env->IsInstanceOf(JavaValue, JSONArrayClass))
+	{
+		// JSONArray doesn't implement Collection & needs special handling
+		TArray<FString> StringArray;
+		jint Length = Env->CallIntMethod(JavaValue, JSONArrayLengthMethod);
+		if (HandleException(Env, TEXT("JSONArray.length()")))
+		{
+			return FCleverTapPropertyValue(StringArray);
+		}
+		for (jint i = 0; i < Length; ++i)
+		{
+			jstring Element = static_cast<jstring>(Env->CallObjectMethod(JavaValue, JSONArrayGetMethod, i));
+			if (HandleExceptionOrError(Env, !Element, TEXT("JSONArray.getString()")))
+			{
+				continue;
+			}
+			const char* UTFChars = Env->GetStringUTFChars(Element, nullptr);
+			StringArray.Add(FString(UTF8_TO_TCHAR(UTFChars)));
+			Env->ReleaseStringUTFChars(Element, UTFChars);
+			Env->DeleteLocalRef(Element);
+		}
+
 		return FCleverTapPropertyValue(StringArray);
 	}
 

--- a/Plugins/CleverTap/Source/CleverTap/Private/Android/AndroidCleverTapSDK.cpp
+++ b/Plugins/CleverTap/Source/CleverTap/Private/Android/AndroidCleverTapSDK.cpp
@@ -107,6 +107,19 @@ public:
 		Env->DeleteLocalRef(JavaItems);
 	}
 
+	TOptional<FCleverTapPropertyValue> GetProperty(const FString& Key) override
+	{
+		auto* Env = JNI::GetJNIEnv();
+		jobject JavaValue = JNI::GetProperty(Env, JavaCleverTapInstance, Key);
+		if (JavaValue == nullptr)
+		{
+			return {};
+		}
+		FCleverTapPropertyValue Value = JNI::ConvertJavaObjectToCleverTapPropertyValue(Env, JavaValue);
+		Env->DeleteLocalRef(JavaValue);
+		return Value;
+	}
+
 	void DecrementValue(const FString& Key, int Amount) override
 	{
 		JNI::DecrementValue(JNI::GetJNIEnv(), JavaCleverTapInstance, Key, Amount);
@@ -125,6 +138,36 @@ public:
 	void IncrementValue(const FString& Key, double Amount) override
 	{
 		JNI::IncrementValue(JNI::GetJNIEnv(), JavaCleverTapInstance, Key, Amount);
+	}
+
+	void AddMultiValueForKey(const FString& Key, const FString& Value) override
+	{
+		JNI::AddMultiValueForKey(JNI::GetJNIEnv(), JavaCleverTapInstance, Key, Value);
+	}
+
+	void AddMultiValuesForKey(const FString& Key, const TArray<FString> Values) override
+	{
+		JNI::AddMultiValuesForKey(JNI::GetJNIEnv(), JavaCleverTapInstance, Key, Values);
+	}
+
+	void RemoveMultiValueForKey(const FString& Key, const FString& Value) override
+	{
+		JNI::RemoveMultiValueForKey(JNI::GetJNIEnv(), JavaCleverTapInstance, Key, Value);
+	}
+
+	void RemoveMultiValuesForKey(const FString& Key, const TArray<FString>& Values) override
+	{
+		JNI::RemoveMultiValuesForKey(JNI::GetJNIEnv(), JavaCleverTapInstance, Key, Values);
+	}
+
+	void RemoveValueForKey(const FString& Key) override
+	{
+		JNI::RemoveValueForKey(JNI::GetJNIEnv(), JavaCleverTapInstance, Key);
+	}
+
+	void SetMultiValuesForKey(const FString& Key, const TArray<FString> Values) override
+	{
+		JNI::SetMultiValuesForKey(JNI::GetJNIEnv(), JavaCleverTapInstance, Key, Values);
 	}
 
 	bool LocalizeAndroidNotificationChannel(

--- a/Plugins/CleverTap/Source/CleverTap/Private/Android/AndroidJNIUtilities.cpp
+++ b/Plugins/CleverTap/Source/CleverTap/Private/Android/AndroidJNIUtilities.cpp
@@ -367,4 +367,33 @@ FString JavaStringArrayToString(JNIEnv* Env, jobjectArray Array)
 	return Output;
 }
 
+jobject StringArrayToJavaArrayList(JNIEnv* Env, const TArray<FString>& StringArray)
+{
+	static jclass ArrayListClass = CacheClass(Env, "java/util/ArrayList");
+	static jmethodID ArrayListConstructor = GetMethodID(Env, ArrayListClass, "<init>", "()V");
+	static jmethodID ArrayListAddMethod = GetMethodID(Env, ArrayListClass, "add", "(Ljava/lang/Object;)Z");
+	if (!ArrayListConstructor || !ArrayListAddMethod)
+	{
+		return nullptr;
+	}
+
+	jobject JavaArrayList = Env->NewObject(ArrayListClass, ArrayListConstructor);
+	if (HandleExceptionOrError(Env, !JavaArrayList, "Constructing ArrayList"))
+	{
+		return nullptr;
+	}
+
+	for (const FString& Item : StringArray)
+	{
+		jstring JavaItem = Env->NewStringUTF(TCHAR_TO_UTF8(*Item));
+		Env->CallBooleanMethod(JavaArrayList, ArrayListAddMethod, JavaItem);
+		if (HandleException(Env, "ArrayList.add()"))
+		{
+			// failed but logged; keep going
+		}
+		Env->DeleteLocalRef(JavaItem);
+	}
+	return JavaArrayList;
+}
+
 }}} // namespace CleverTapSDK::Android::JNI

--- a/Plugins/CleverTap/Source/CleverTap/Private/Android/AndroidJNIUtilities.h
+++ b/Plugins/CleverTap/Source/CleverTap/Private/Android/AndroidJNIUtilities.h
@@ -121,4 +121,7 @@ FString JavaObjectToString(JNIEnv* Env, jobject JavaObject);
 /** Converts a Java Array<String> to an Unreal FString for debugging. */
 FString JavaStringArrayToString(JNIEnv* Env, jobjectArray Array);
 
+/** Converts an unreal TArray<FString> to a Java ArrayList<String> */
+jobject StringArrayToJavaArrayList(JNIEnv* Env, const TArray<FString>& StringArray);
+
 }}} // namespace CleverTapSDK::Android::JNI

--- a/Plugins/CleverTap/Source/CleverTap/Private/CleverTapProperties.cpp
+++ b/Plugins/CleverTap/Source/CleverTap/Private/CleverTapProperties.cpp
@@ -155,6 +155,18 @@ FString ToDebugString(const FCleverTapPropertyValue& Value)
 	return Value.GetDebugString();
 }
 
+FString ToDebugString(const TOptional<FCleverTapPropertyValue>& OptionalValue)
+{
+	if (OptionalValue.IsSet())
+	{
+		return ToDebugString(OptionalValue.GetValue());
+	}
+	else
+	{
+		return TEXT("<not set>");
+	}
+}
+
 FString ToDebugString(const FCleverTapProperties& Properties)
 {
 	FString Result = TEXT("{ ");

--- a/Plugins/CleverTap/Source/CleverTap/Private/NullCleverTapInstance.cpp
+++ b/Plugins/CleverTap/Source/CleverTap/Private/NullCleverTapInstance.cpp
@@ -39,6 +39,12 @@ void FNullCleverTapInstance::PushChargedEvent(
 	CleverTapSDK::Ignore(ChargeDetails, Items);
 }
 
+TOptional<FCleverTapPropertyValue> FNullCleverTapInstance::GetProperty(const FString& Key)
+{
+	CleverTapSDK::Ignore(Key);
+	return {};
+}
+
 void FNullCleverTapInstance::DecrementValue(const FString& Key, int Amount)
 {
 	CleverTapSDK::Ignore(Key, Amount);
@@ -57,6 +63,36 @@ void FNullCleverTapInstance::IncrementValue(const FString& Key, int Amount)
 void FNullCleverTapInstance::IncrementValue(const FString& Key, double Amount)
 {
 	CleverTapSDK::Ignore(Key, Amount);
+}
+
+void FNullCleverTapInstance::AddMultiValueForKey(const FString& Key, const FString& Value)
+{
+	CleverTapSDK::Ignore(Key, Value);
+}
+
+void FNullCleverTapInstance::AddMultiValuesForKey(const FString& Key, const TArray<FString> Values)
+{
+	CleverTapSDK::Ignore(Key, Values);
+}
+
+void FNullCleverTapInstance::RemoveMultiValueForKey(const FString& Key, const FString& Value)
+{
+	CleverTapSDK::Ignore(Key, Value);
+}
+
+void FNullCleverTapInstance::RemoveMultiValuesForKey(const FString& Key, const TArray<FString>& Values)
+{
+	CleverTapSDK::Ignore(Key, Values);
+}
+
+void FNullCleverTapInstance::RemoveValueForKey(const FString& Key)
+{
+	CleverTapSDK::Ignore(Key);
+}
+
+void FNullCleverTapInstance::SetMultiValuesForKey(const FString& Key, const TArray<FString> Values)
+{
+	CleverTapSDK::Ignore(Key, Values);
 }
 
 ECleverTapPushPermissionStatus FNullCleverTapInstance::GetPushPermissionStatus()

--- a/Plugins/CleverTap/Source/CleverTap/Private/NullCleverTapInstance.h
+++ b/Plugins/CleverTap/Source/CleverTap/Private/NullCleverTapInstance.h
@@ -21,11 +21,20 @@ public:
 	void PushChargedEvent(
 		const FCleverTapProperties& ChargeDetails, const TArray<FCleverTapProperties>& Items) override;
 
+	TOptional<FCleverTapPropertyValue> GetProperty(const FString& Key) override;
+
 	void DecrementValue(const FString& Key, int Amount) override;
 	void DecrementValue(const FString& Key, double Amount) override;
 
 	void IncrementValue(const FString& Key, int Amount) override;
 	void IncrementValue(const FString& Key, double Amount) override;
+
+	void AddMultiValueForKey(const FString& Key, const FString& Value) override;
+	void AddMultiValuesForKey(const FString& Key, const TArray<FString> Values) override;
+	void RemoveMultiValueForKey(const FString& Key, const FString& Value) override;
+	void RemoveMultiValuesForKey(const FString& Key, const TArray<FString>& Values) override;
+	void RemoveValueForKey(const FString& Key) override;
+	void SetMultiValuesForKey(const FString& Key, const TArray<FString> Values) override;
 
 	ECleverTapPushPermissionStatus GetPushPermissionStatus() override;
 	void PromptForPushPermission(bool bFallbackToSettings) override;

--- a/Plugins/CleverTap/Source/CleverTap/Public/CleverTapInstance.h
+++ b/Plugins/CleverTap/Source/CleverTap/Public/CleverTapInstance.h
@@ -79,6 +79,13 @@ public:
 	virtual void PushProfile(const FCleverTapProperties& Profile) = 0;
 
 	/**
+	 * Returns the user profile property value for the given key, or an empty optional if not found.
+	 *
+	 * NOTE: May not reflect recent changes immediately due to asynchronous updates in the SDK.
+	 */
+	virtual TOptional<FCleverTapPropertyValue> GetProperty(const FString& Key) = 0;
+
+	/**
 	 * Decrement a user profile property by the specified amount. The property type must be an integer, float, or
 	 *  double. The Amount value should be zero or greater than zero.
 	 */
@@ -101,6 +108,66 @@ public:
 	 *  double. The Amount value should be zero or greater than zero.
 	 */
 	virtual void IncrementValue(const FString& Key, double Amount) = 0;
+
+	/**
+	 * Add a unique value to a multi-value user profile property
+	 * If the property does not exist it will be created.
+	 *
+	 * Max 100 values, on reaching 100 cap, oldest value(s) will be removed.
+	 * Values must be Strings and are limited to 512 characters.
+	 *
+	 * If the key currently contains a scalar value, the key will be promoted to a multi-value property
+	 * with the current value cast to a string and the new value(s) added
+	 */
+	virtual void AddMultiValueForKey(const FString& Key, const FString& Value) = 0;
+
+	/**
+	 * Add a collection of unique values to a multi-value user profile property
+	 * If the property does not exist it will be created
+	 *
+	 * Max 100 values, on reaching 100 cap, oldest value(s) will be removed.
+	 * Values must be Strings and are limited to 512 characters.
+	 *
+	 * If the key currently contains a scalar value, the key will be promoted to a multi-value property
+	 * with the current value cast to a string and the new value(s) added
+	 */
+	virtual void AddMultiValuesForKey(const FString& Key, const TArray<FString> Values) = 0;
+
+	/**
+	 * Remove a unique value from a multi-value user profile property.
+	 *
+	 * If the key currently contains a scalar value, prior to performing the remove operation
+	 * the key will be promoted to a multi-value property with the current value cast to a string.
+	 * If the multi-value property is empty after the remove operation, the key will be removed.
+	 */
+	virtual void RemoveMultiValueForKey(const FString& Key, const FString& Value) = 0;
+
+	/**
+	 * Remove a collection of unique values from a multi-value user profile property
+	 *
+	 * If the key currently contains a scalar value, prior to performing the remove operation
+	 * the key will be promoted to a multi-value property with the current value cast to a string.
+	 *
+	 * If the multi-value property is empty after the remove operation, the key will be removed.
+	 */
+	virtual void RemoveMultiValuesForKey(const FString& Key, const TArray<FString>& Values) = 0;
+
+	/**
+	 * Remove the user profile property value specified by key from the user profile.
+	 *
+	 * This method can be used to remove PII data (for eg. Email,Name,Phone), locally from database and shared prefs.
+	 */
+	virtual void RemoveValueForKey(const FString& Key) = 0;
+
+	/**
+	 * Set a collection of unique values as a multi-value user profile property.
+	 *
+	 * Any existing value will be overwritten.
+	 *
+	 * Max 100 values, on reaching 100 cap, oldest value(s) will be removed.
+	 * Values must be Strings and are limited to 512 characters.
+	 */
+	virtual void SetMultiValuesForKey(const FString& Key, const TArray<FString> Values) = 0;
 
 	/**
 	 * Record a user event on the user's profile with the specified event name.

--- a/Plugins/CleverTap/Source/CleverTap/Public/CleverTapInstance.h
+++ b/Plugins/CleverTap/Source/CleverTap/Public/CleverTapInstance.h
@@ -82,6 +82,9 @@ public:
 	 * Returns the user profile property value for the given key, or an empty optional if not found.
 	 *
 	 * NOTE: May not reflect recent changes immediately due to asynchronous updates in the SDK.
+	 *
+	 * NOTE: Date related property values are returned as number of seconds since January 1, 1970, 00:00:00 GMT,
+	 *       not the FCleverTapDate type used to set them.
 	 */
 	virtual TOptional<FCleverTapPropertyValue> GetProperty(const FString& Key) = 0;
 

--- a/Plugins/CleverTap/Source/CleverTap/Public/CleverTapProperties.h
+++ b/Plugins/CleverTap/Source/CleverTap/Public/CleverTapProperties.h
@@ -117,5 +117,8 @@ using FCleverTapProperties = TMap<FString, FCleverTapPropertyValue>;
 /** Returns a debug string describing the property's value and type. */
 CLEVERTAP_API FString ToDebugString(const FCleverTapPropertyValue& Value);
 
+/** Returns a debug string describing the property's value and type, or "<not set>" if not set. */
+CLEVERTAP_API FString ToDebugString(const TOptional<FCleverTapPropertyValue>& OptionalValue);
+
 /** Returns a debug string listing all properties with their keys, types, and values. */
 CLEVERTAP_API FString ToDebugString(const FCleverTapProperties& Properties);

--- a/Source/CleverTapSample/Private/SampleMainMenu.cpp
+++ b/Source/CleverTapSample/Private/SampleMainMenu.cpp
@@ -417,6 +417,29 @@ void USampleMainMenu::PushProfileDataTypeTest()
 	check(CleverTapSys->IsSharedInstanceInitialized());
 	ICleverTapInstance& CleverTap = CleverTapSys->SharedInstance();
 	CleverTap.PushProfile(Profile);
+
+	// can increment/decrement number properties
+	CleverTap.IncrementValue("Test_Long", 3);
+	CleverTap.DecrementValue("Test_Long", 1);
+	CleverTap.IncrementValue("Test_Double", 3.3);
+	CleverTap.DecrementValue("Test_Double", 1.1);
+
+	// exercise the multi-value methods;
+	// should result in an array holding just "four", but it's async!
+	CleverTap.RemoveValueForKey("Test_MVM");
+	CleverTap.AddMultiValueForKey("Test_MVM", "one");
+	CleverTap.AddMultiValuesForKey("Test_MVM", { "two", "three", "four" });
+	CleverTap.RemoveMultiValueForKey("Test_MVM", "three");
+	CleverTap.RemoveMultiValuesForKey("Test_MVM", { "one", "two" });
+
+	// Exercise GetProperty() on each type.
+	// As the above modifications happen asynchronously. GetProperty() will take awhile to be updated with the new profile values.
+	// The below will likely only show the correct output on the second call to this function.
+	for (const auto Pair : Profile)
+	{
+		UE_LOG(LogCleverTapSample, Log, TEXT("%s=%s"), *Pair.Key, *ToDebugString(CleverTap.GetProperty(Pair.Key)));
+	}
+	UE_LOG(LogCleverTapSample, Log, TEXT("Test_MVM=%s"), *ToDebugString(CleverTap.GetProperty("Test_MVM")));
 }
 
 void USampleMainMenu::RecordEvent(const FString& EventName, const TArray<FCleverTapSampleKeyValuePair>& Params)


### PR DESCRIPTION
Adds `GetProperty()`, `AddMultiValueForKey()`, `AddMultiValuesForKey()`, `RemoveMultiValueForKey()`, `RemoveMultiValuesForKey()`, `RemoveValueForKey()`, `SetMultiValuesForKey()` to the CleverTapInstance API with Android implementations.