### PR TITLE
Android support for EncryptionLevel

### DIFF
--- a/Config/DefaultEngine.ini
+++ b/Config/DefaultEngine.ini
@@ -133,6 +133,7 @@ ProjectId=YOUR_CLEVERTAP_PROJECT_ID
 ProjectToken=YOUR_CLEVERTAP_TOKEN
 RegionCode=
 IdentityKeys=Identity,Email,Phone
+EncryptionLevel=None
 bUseCustomCleverTapId=False
 bRequestInternetPermissions=True
 bRequestGeoFencePermissions=False

--- a/Plugins/CleverTap/Source/CleverTap/CleverTap_Android_UPL.xml
+++ b/Plugins/CleverTap/Source/CleverTap/CleverTap_Android_UPL.xml
@@ -6,6 +6,7 @@
 		<setStringFromProperty result="CTProjectToken" ini="Engine" section="/Script/CleverTap.CleverTapConfig" property="ProjectToken" default="" />
 		<setStringFromProperty result="CTRegionCode" ini="Engine" section="/Script/CleverTap.CleverTapConfig" property="RegionCode" default="" />
 		<setStringFromProperty result="CTIdentityKeys" ini="Engine" section="/Script/CleverTap.CleverTapConfig" property="IdentityKeys" default="Identity,Email,Phone" />
+		<setStringFromProperty result="CTEncryptionLevel" ini="Engine" section="/Script/CleverTap.CleverTapConfig" property="EncryptionLevel" default="None" />
 		<setBoolFromProperty result="CTUseCustomId" ini="Engine" section="/Script/CleverTap.CleverTapConfig" property="bUseCustomCleverTapId" default="false" />
 		<setBoolFromProperty result="CTRequestInternetPermissions" ini="Engine" section="/Script/CleverTap.CleverTapConfig" property="bRequestInternetPermissions" default="true" />
 		<setBoolFromProperty result="CTRequestGeoFencePermissions" ini="Engine" section="/Script/CleverTap.CleverTapConfig" property="bRequestGeoFencePermissions" default="false" />
@@ -87,6 +88,39 @@
 				<addAttribute tag="$CLEVERTAP_IDENTIFIER" name="android:name" value="CLEVERTAP_IDENTIFIER" />
 				<addAttribute tag="$CLEVERTAP_IDENTIFIER" name="android:value" value="$S(CTIdentityKeys)" />
 				<addElement tag="application" name="CLEVERTAP_IDENTIFIER" />
+
+				<setBoolIsEqual result="EncryptionLevelIsEmpty" arg1="$S(CTEncryptionLevel)" arg2="" />
+				<if condition="EncryptionLevelIsEmpty">
+					<false>
+						<setBool result="EncryptionValusIsKnown" value="false" />
+						<setBoolIsEqual result="EncryptionLevelIsNone" arg1="$S(CTEncryptionLevel)" arg2="None" />
+						<if condition="EncryptionLevelIsNone">
+							<true>
+								<setString result="EncryptionLevelValue" value="0" />
+								<setBool result="EncryptionValusIsKnown" value="true" />
+							</true>
+						</if>
+						<setBoolIsEqual result="EncryptionLevelIsMedium" arg1="$S(CTEncryptionLevel)" arg2="Medium" />
+						<if condition="EncryptionLevelIsMedium">
+							<true>
+								<setString result="EncryptionLevelValue" value="1" />
+								<setBool result="EncryptionValusIsKnown" value="true" />
+							</true>
+						</if>
+
+						<if condition="EncryptionValusIsKnown">
+							<true>
+								<setElement result="CLEVERTAP_ENCRYPTION_LEVEL" xml="&lt;meta-data/&gt;" />
+								<addAttribute tag="$CLEVERTAP_ENCRYPTION_LEVEL" name="android:name" value="CLEVERTAP_ENCRYPTION_LEVEL" />
+								<addAttribute tag="$CLEVERTAP_ENCRYPTION_LEVEL" name="android:value" value="$S(EncryptionLevelValue)" />
+								<addElement tag="application" name="CLEVERTAP_ENCRYPTION_LEVEL" />
+							</true>
+							<false>
+								<log text="Error: Unknown Encryption level $S(CTEncryptionLevel)!" />
+							</false>
+						</if>
+					</false>
+				</if>
 
 				<if condition="CTEnableBackgroundSync">
 					<true>

--- a/Plugins/CleverTap/Source/CleverTap/Private/Android/AndroidCleverTapJNI.cpp
+++ b/Plugins/CleverTap/Source/CleverTap/Private/Android/AndroidCleverTapJNI.cpp
@@ -113,6 +113,69 @@ static jobject CleverTapEncryptionLevelToJava(JNIEnv* Env, ECleverTapEncryptionL
 	return JavaEncryptionLevelFromString(Env, CleverTapEncryptionLevelJavaName(EncryptionLevel));
 }
 
+/** Returns the name of each ECleverTapLogLevel value in the Java */
+static const char* CleverTapLogLevelJavaName(ECleverTapLogLevel LogLevel)
+{
+	switch (LogLevel)
+	{
+		case ECleverTapLogLevel::Off:
+			return "OFF";
+		case ECleverTapLogLevel::Info:
+			return "INFO";
+		case ECleverTapLogLevel::Debug:
+			return "DEBUG";
+		case ECleverTapLogLevel::Verbose:
+			return "VERBOSE";
+		default:
+		{
+			UE_LOG(
+				LogCleverTap, Error, TEXT("Unhandled ECleverTapLogLevel value. Defaulting to ECleverTapLogLevel::Off"));
+			return "OFF";
+		}
+	}
+}
+
+static jobject CleverTapLogLevelToJava(JNIEnv* Env, ECleverTapLogLevel LogLevel)
+{
+	static jclass LogLevelClass = CacheClass(Env, "com/clevertap/android/sdk/CleverTapAPI$LogLevel");
+	static jmethodID ValueOfMethod = GetStaticMethodID(
+		Env, LogLevelClass, "valueOf", "(Ljava/lang/String;)Lcom/clevertap/android/sdk/CleverTapAPI$LogLevel;");
+	if (!ValueOfMethod)
+	{
+		return nullptr;
+	}
+	jstring JavaLevelName = Env->NewStringUTF(CleverTapLogLevelJavaName(LogLevel));
+	jobject LogLevelEnumValue = Env->CallStaticObjectMethod(LogLevelClass, ValueOfMethod, JavaLevelName);
+	if (ExceptionThrown(Env) || !LogLevelEnumValue)
+	{
+		HandleExceptionOrError(Env, !LogLevelEnumValue,
+			FString::Printf(TEXT("Failed to get LogLevel enum for: %s"), *CleverTapLogLevelJavaName(LogLevel)));
+		LogLevelEnumValue = nullptr;
+		// fall through
+	}
+	Env->DeleteLocalRef(JavaLevelName);
+	return LogLevelEnumValue;
+}
+
+static int CleverTapLogLevelToJavaInt(JNIEnv* Env, ECleverTapLogLevel Level)
+{
+	static jclass LogLevelClass = CacheClass(Env, "com/clevertap/android/sdk/CleverTapAPI$LogLevel");
+	static jmethodID OrdinalMethod = Env->GetMethodID(LogLevelClass, "ordinal", "()I");
+
+	jobject EnumObject = CleverTapLogLevelToJava(Env, Level);
+	if (!EnumObject)
+	{
+		return 0;
+	}
+	jint Ordinal = Env->CallIntMethod(EnumObject, OrdinalMethod);
+	if (HandleException(Env, "LogLevel.ordinal()"))
+	{
+		// fall through
+	}
+	Env->DeleteLocalRef(EnumObject);
+	return Ordinal;
+}
+
 static jobject CreateCleverTapInstanceConfig(JNIEnv* Env, const FCleverTapInstanceConfig& Config)
 {
 	static jclass ConfigClass = CacheClass(Env, "com/clevertap/android/sdk/CleverTapInstanceConfig");
@@ -120,7 +183,8 @@ static jobject CreateCleverTapInstanceConfig(JNIEnv* Env, const FCleverTapInstan
 		"(Landroid/content/Context;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lcom/clevertap/android/sdk/CleverTapInstanceConfig;");
 	static jmethodID SetEncryptionMethod =
 		GetMethodID(Env, ConfigClass, "setEncryptionLevel", "(Lcom/clevertap/android/sdk/cryption/EncryptionLevel;)V");
-	if (!CreateMethod || !SetEncryptionMethod)
+	static jmethodID SetDebugLevelMethod = GetMethodID(Env, ConfigClass, "setDebugLevel", "(I)V");
+	if (!CreateMethod || !SetEncryptionMethod || !SetDebugLevelMethod)
 	{
 		return nullptr;
 	}
@@ -155,8 +219,10 @@ static jobject CreateCleverTapInstanceConfig(JNIEnv* Env, const FCleverTapInstan
 	HandleException(Env, TEXT("CleverTapInstanceConfig.setEncryptionLevel() failed!"));
 	Env->DeleteLocalRef(JavaEncryption);
 
-	// set the log level
-	// --> todo <<---
+	// set the log level; this version needs the java-side int value instead of the enum
+	int JavaLevelInt = CleverTapLogLevelToJavaInt(Env, Config.LogLevel);
+	Env->CallVoidMethod(ConfigInstance, SetDebugLevelMethod, JavaLevelInt);
+	HandleException(Env, TEXT("CleverTapInstanceConfig.setDebugLevel() failed!"));
 
 	return ConfigInstance;
 }
@@ -232,53 +298,9 @@ jobject GetDefaultInstance(JNIEnv* Env, const FString& CleverTapId)
 	return CleverTapInstance;
 }
 
-static jobject JavaLogLevelFromString(JNIEnv* Env, const char* LogLevelName)
-{
-	static jclass LogLevelClass = CacheClass(Env, "com/clevertap/android/sdk/CleverTapAPI$LogLevel");
-	static jmethodID ValueOfMethod = GetStaticMethodID(
-		Env, LogLevelClass, "valueOf", "(Ljava/lang/String;)Lcom/clevertap/android/sdk/CleverTapAPI$LogLevel;");
-	if (!ValueOfMethod)
-	{
-		return nullptr;
-	}
-	// Get the enum constant from the name
-	jstring JavaLogLevelName = Env->NewStringUTF(LogLevelName);
-	jobject LogLevelEnumValue = Env->CallStaticObjectMethod(LogLevelClass, ValueOfMethod, JavaLogLevelName);
-	if (ExceptionThrown(Env) || !LogLevelEnumValue)
-	{
-		HandleExceptionOrError(
-			Env, !LogLevelEnumValue, FString::Printf(TEXT("Failed to get LogLevel enum for: %s"), *LogLevelName));
-		LogLevelEnumValue = nullptr;
-		// fall through
-	}
-	Env->DeleteLocalRef(JavaLogLevelName);
-	return LogLevelEnumValue;
-}
-
-static const char* CleverTapLogLevelName(ECleverTapLogLevel Level)
-{
-	switch (Level)
-	{
-		case ECleverTapLogLevel::Off:
-			return "OFF";
-		case ECleverTapLogLevel::Info:
-			return "INFO";
-		case ECleverTapLogLevel::Debug:
-			return "DEBUG";
-		case ECleverTapLogLevel::Verbose:
-			return "VERBOSE";
-		default:
-		{
-			UE_LOG(
-				LogCleverTap, Error, TEXT("Unhandled ECleverTapLogLevel value. Defaulting to ECleverTapLogLevel::Off"));
-			return "OFF";
-		}
-	}
-}
-
 bool SetDebugLevel(JNIEnv* Env, ECleverTapLogLevel Level)
 {
-	const char* LevelName = CleverTapLogLevelName(Level);
+	const char* LevelName = CleverTapLogLevelJavaName(Level);
 	UE_LOG(LogCleverTap, Log, TEXT("CleverTapSDK::Android::JNI::SetDebugLevel(%hs)"), LevelName);
 	static jclass CleverTapAPIClass = GetCleverTapAPIClass(Env);
 	static jmethodID SetDebugLogLevelMethod = GetStaticMethodID(
@@ -288,7 +310,7 @@ bool SetDebugLevel(JNIEnv* Env, ECleverTapLogLevel Level)
 		return false;
 	}
 
-	jobject JavaLogLevel = JavaLogLevelFromString(Env, LevelName);
+	jobject JavaLogLevel = CleverTapLogLevelToJava(Env, Level);
 	if (!JavaLogLevel)
 	{
 		return false;
@@ -799,5 +821,4 @@ void PromptPushPrimer(JNIEnv* Env, jobject CleverTapInstance, jobject PrimerConf
 		// fall through
 	}
 }
-
 }}} // namespace CleverTapSDK::Android::JNI

--- a/Plugins/CleverTap/Source/CleverTap/Private/Android/AndroidCleverTapJNI.cpp
+++ b/Plugins/CleverTap/Source/CleverTap/Private/Android/AndroidCleverTapJNI.cpp
@@ -67,12 +67,60 @@ static void SetIdentityKeys(JNIEnv* Env, jobject ConfigInstance, const TArray<FS
 	Env->DeleteLocalRef(KeyArray);
 }
 
+static jobject JavaEncryptionLevelFromString(JNIEnv* Env, const char* LevelName)
+{
+	static jclass EncryptionLevelClass = CacheClass(Env, "com/clevertap/android/sdk/cryption/EncryptionLevel");
+	static jmethodID ValueOfMethod = GetStaticMethodID(Env, EncryptionLevelClass, "valueOf",
+		"(Ljava/lang/String;)Lcom/clevertap/android/sdk/cryption/EncryptionLevel;");
+	if (!ValueOfMethod)
+	{
+		return nullptr;
+	}
+	// Get the enum constant from the name
+	jstring JavaLevelName = Env->NewStringUTF(LevelName);
+	jobject LevelEnumValue = Env->CallStaticObjectMethod(EncryptionLevelClass, ValueOfMethod, JavaLevelName);
+	if (ExceptionThrown(Env) || !LevelEnumValue)
+	{
+		HandleExceptionOrError(
+			Env, !LevelEnumValue, FString::Printf(TEXT("Failed to get EncryptionLevel enum for: %s"), *LevelName));
+		LevelEnumValue = nullptr;
+		// fall through
+	}
+	Env->DeleteLocalRef(JavaLevelName);
+	return LevelEnumValue;
+}
+
+/** returns the Java string for the corresponding enum value, so we can ask java for its value */
+static const char* CleverTapEncryptionLevelJavaName(ECleverTapEncryptionLevel Level)
+{
+	switch (Level)
+	{
+		case ECleverTapEncryptionLevel::None:
+			return "NONE";
+		case ECleverTapEncryptionLevel::Medium:
+			return "MEDIUM";
+		default:
+		{
+			UE_LOG(LogCleverTap, Error,
+				TEXT("Unhandled ECleverTapEncryptionLevel value. Defaulting to ECleverTapEncryptionLevel::None"));
+			return "NONE";
+		}
+	}
+}
+
+static jobject CleverTapEncryptionLevelToJava(JNIEnv* Env, ECleverTapEncryptionLevel EncryptionLevel)
+{
+	return JavaEncryptionLevelFromString(Env, CleverTapEncryptionLevelJavaName(EncryptionLevel));
+}
+
 static jobject CreateCleverTapInstanceConfig(JNIEnv* Env, const FCleverTapInstanceConfig& Config)
 {
 	static jclass ConfigClass = CacheClass(Env, "com/clevertap/android/sdk/CleverTapInstanceConfig");
 	static jmethodID CreateMethod = GetStaticMethodID(Env, ConfigClass, "createInstance",
 		"(Landroid/content/Context;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lcom/clevertap/android/sdk/CleverTapInstanceConfig;");
-	if (!CreateMethod)
+	static jmethodID SetEncryptionMethod =
+		GetMethodID(Env, ConfigClass, "setEncryptionLevel", "(Lcom/clevertap/android/sdk/cryption/EncryptionLevel;)V");
+	if (!CreateMethod || !SetEncryptionMethod)
 	{
 		return nullptr;
 	}
@@ -93,9 +141,22 @@ static jobject CreateCleverTapInstanceConfig(JNIEnv* Env, const FCleverTapInstan
 	Env->DeleteLocalRef(JAccountId);
 	Env->DeleteLocalRef(JAccountToken);
 	Env->DeleteLocalRef(JAccountRegion);
+	if (!ConfigInstance)
+	{
+		return nullptr;
+	}
 
 	// install the identity keys
 	SetIdentityKeys(Env, ConfigInstance, Config.GetIdentityKeys());
+
+	// set the encryption level
+	jobject JavaEncryption = CleverTapEncryptionLevelToJava(Env, Config.EncryptionLevel);
+	Env->CallVoidMethod(ConfigInstance, SetEncryptionMethod, JavaEncryption);
+	HandleException(Env, TEXT("CleverTapInstanceConfig.setEncryptionLevel() failed!"));
+	Env->DeleteLocalRef(JavaEncryption);
+
+	// set the log level
+	// --> todo <<---
 
 	return ConfigInstance;
 }

--- a/Plugins/CleverTap/Source/CleverTap/Private/CleverTapInstanceConfig.cpp
+++ b/Plugins/CleverTap/Source/CleverTap/Private/CleverTapInstanceConfig.cpp
@@ -16,6 +16,7 @@ FCleverTapInstanceConfig FCleverTapInstanceConfig::FromCleverTapConfig(const UCl
 	InstanceConfig.ProjectToken = Config->ProjectToken;
 	InstanceConfig.RegionCode = Config->RegionCode;
 	InstanceConfig.IdentityKeys = Config->IdentityKeys;
+	InstanceConfig.EncryptionLevel = Config->EncryptionLevel;
 	InstanceConfig.LogLevel = Config->GetActiveLogLevel();
 	return InstanceConfig;
 }

--- a/Plugins/CleverTap/Source/CleverTap/Public/CleverTapConfig.h
+++ b/Plugins/CleverTap/Source/CleverTap/Public/CleverTapConfig.h
@@ -2,6 +2,7 @@
 #pragma once
 
 #include "CoreMinimal.h"
+#include "CleverTapEncryptionLevel.h"
 #include "CleverTapLogLevel.h"
 #include "CleverTapConfig.generated.h"
 
@@ -63,6 +64,12 @@ public:
 	 */
 	UPROPERTY(config, EditAnywhere, BlueprintReadOnly)
 	bool bUseCustomCleverTapId = false;
+
+	/**
+	 * The encryption level to use for PII
+	 */
+	UPROPERTY(config, EditAnywhere, BlueprintReadOnly)
+	ECleverTapEncryptionLevel EncryptionLevel = ECleverTapEncryptionLevel::None;
 
 	/** Request internet permissions in the application manifest.
 	 *  Required for CleverTap to work.

--- a/Plugins/CleverTap/Source/CleverTap/Public/CleverTapEncryptionLevel.h
+++ b/Plugins/CleverTap/Source/CleverTap/Public/CleverTapEncryptionLevel.h
@@ -1,0 +1,18 @@
+// Copyright CleverTap All Rights Reserved.
+#pragma once
+
+#include "CoreMinimal.h"
+#include "CleverTapEncryptionLevel.generated.h"
+
+/**
+ * Log level for the platform's CleverTap SDK implementation
+ */
+UENUM(BlueprintType)
+enum class ECleverTapEncryptionLevel : uint8
+{
+	// All stored data is in plaintext
+	None,
+
+	// PII data is encrypted completely
+	Medium,
+};

--- a/Plugins/CleverTap/Source/CleverTap/Public/CleverTapInstanceConfig.h
+++ b/Plugins/CleverTap/Source/CleverTap/Public/CleverTapInstanceConfig.h
@@ -1,6 +1,7 @@
 // Copyright CleverTap All Rights Reserved.
 #pragma once
 
+#include "CleverTapEncryptionLevel.h"
 #include "CleverTapLogLevel.h"
 #include "CoreMinimal.h"
 
@@ -40,6 +41,11 @@ struct FCleverTapInstanceConfig
 	 * Returns the IdentityKeys field as an array.
 	 */
 	TArray<FString> GetIdentityKeys() const;
+
+	/**
+	 * The encryption level to use for PII
+	 */
+	ECleverTapEncryptionLevel EncryptionLevel = ECleverTapEncryptionLevel::None;
 
 	/**
 	 * The platform SDK log level to use

--- a/README.md
+++ b/README.md
@@ -50,8 +50,24 @@ will automatically initialize the CleverTap SDK and the default shared instance.
 > Config.ProjectToken = /*Your project token*/;
 > Config.RegionCode = /*Region code*/;
 > Config.LogLevel = /*ECleverTapLogLevel enum specifying your desired CleverTap SDK log verbosity*/;
+> Config.EncryptionLevel  = /* ECleverTapEncryptionLevel enum setting the PII encrytion level */
 > GEngine->GetEngineSubsystem<UCleverTapSubsystem>()->InitializeSharedInstance(Config);
 > ```
+
+## Encryption of PII Data
+PII data is stored across the SDK and could be sensitive information. 
+You can enable encryption for PII data such as Email, Identity, Name, and Phone.
+Currently, two levels of encryption are supported:
+- None: All stored data is in plaintext (the default)
+- Medium: PII data is encrypted completely
+
+The only way to set the encryption level for the default instance is from `Config/DefaultEngine.ini`:
+```ini
+[/Script/CleverTap.CleverTapConfig]
+EncryptionLevel=Medium
+```
+
+Different instances can have different encryption levels. To set an encryption level for an additional instance, set the `EncryptionLevel` field in the `FCleverTapInstanceConfig` used to create it.
 
 
 ## Push Notification Configuration


### PR DESCRIPTION
Adds `ECleverTapEncryptionLevel EncryptionLevel` to the instance configuration and connects Android support.
(Also fixes the Debug Log Level not being respected for the non-default instance).